### PR TITLE
[FIX] support for linear-gradient color value

### DIFF
--- a/lib/html_sanitize_ex/scrubber/css.ex
+++ b/lib/html_sanitize_ex/scrubber/css.ex
@@ -211,7 +211,7 @@ defmodule HtmlSanitizeEx.Scrubber.CSS do
   defp measured_unit?(val) do
     String.match?(
       val,
-      ~r/\A(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|-?\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)\z/
+      ~r/\A(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|rgba\(\d+%?,\d*%?,?\d*%?,?\d*\.?\d*\)?|-?\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)\z/
     )
   end
 end

--- a/lib/html_sanitize_ex/scrubber/css.ex
+++ b/lib/html_sanitize_ex/scrubber/css.ex
@@ -155,9 +155,13 @@ defmodule HtmlSanitizeEx.Scrubber.CSS do
   defp scrub_val(val) do
     val = if String.match?(val, ~r/(\\|&)/), do: "", else: val
 
-    Regex.replace(~r/(\S+)/, val, fn _all, a ->
-      if(allowed_keyword?(a) || measured_unit?(a), do: a, else: "")
-    end)
+    if String.starts_with?(val, "linear-gradient(") and valid_linear_gradient?(val) do
+      val
+    else
+      Regex.replace(~r/(\S+)/, val, fn _all, a ->
+        if(allowed_keyword?(a) || measured_unit?(a), do: a, else: "")
+      end)
+    end
   end
 
   @allowed_keywords [
@@ -212,6 +216,14 @@ defmodule HtmlSanitizeEx.Scrubber.CSS do
     String.match?(
       val,
       ~r/\A(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|rgba\(\d+%?,\d*%?,?\d*%?,?\d*\.?\d*\)?|-?\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)\z/
+    )
+  end
+
+  defp valid_linear_gradient?(val) do
+    val
+    |> String.replace(~r/\s+/, "")
+    |> String.match?(
+      ~r/^linear-gradient\(((rgba?\(\d+%?,\d*%?,?\d*%?(?:,\d*\.?\d*)?\))\s*\d*%?)(?:,\s*(rgba?\(\d+%?,\d*%?,?\d*%?(?:,\d*\.?\d*)?\))\s*\d*%?)*\)$/
     )
   end
 end

--- a/test/css_test.exs
+++ b/test/css_test.exs
@@ -8,7 +8,9 @@ defmodule HtmlSanitizeExScrubberCSSTest do
   @good_css [
     ".test { color: red; border: 1px solid brown; }",
     "div.foo { width: 500px; height: 200px; }",
+    "span.foo { background: linear-gradient(rgba(255, 0, 0, 0) 65%, rgb(255, 0, 0) 35%); }",
     "span.foo { background: rgba(255, 0, 0, 0); }",
+    "span.foo { background: rgb(255, 0, 0); }",
     # gibberish should work
     "GI b gkljfl kj { { { ********"
   ]

--- a/test/css_test.exs
+++ b/test/css_test.exs
@@ -8,6 +8,7 @@ defmodule HtmlSanitizeExScrubberCSSTest do
   @good_css [
     ".test { color: red; border: 1px solid brown; }",
     "div.foo { width: 500px; height: 200px; }",
+    "span.foo { background: rgba(255, 0, 0, 0); }",
     # gibberish should work
     "GI b gkljfl kj { { { ********"
   ]


### PR DESCRIPTION
The underline on ECE uses `linear-gradient` but it's filtered out by the CSS sanitizer. This PR adds support for `linear-gradient` with two colour values declared with `rgb` or `rgba`